### PR TITLE
use query to define scope and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ var registerServiceWorker = require("serviceworker!./sw.js");
 registerServiceWorker({ scope: '/' }).then(success, error);
 ```
 
+## Options
+
+Passing as query parameters:
+- scope: directory to place the script (default: '/')
+- name: filename of the script (default: 'sw.js')
+
 ## Credit
 
 This loader is based almost entirely on [worker-loader](https://github.com/webpack/worker-loader) by [@sokra](https://github.com/sokra).

--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ module.exports.pitch = function(request) {
   });
   workerCompiler.runAsChild(function(err, entries, compilation) {
     if(err) return callback(err);
-    var workerFile = entries[0].files[0];
-    return callback(null, "module.exports = function(options) {\n\treturn navigator.serviceWorker.register(__webpack_public_path__ + " + JSON.stringify(workerFile) + ", options);\n};");
+    if (entries[0]) {
+        var workerFile = entries[0].files[0];
+        return callback(null, "module.exports = function(options) {\n\treturn navigator.serviceWorker.register(__webpack_public_path__ + " + JSON.stringify(workerFile) + ", options);\n};");
+    } else {
+        return callback(null, null);
+    }
   });
 }

--- a/index.js
+++ b/index.js
@@ -8,9 +8,10 @@ module.exports.pitch = function(request) {
   if(!this.webpack) throw new Error("Only usable with webpack");
   var callback = this.async();
   var query = loaderUtils.parseQuery(this.query);
+  var scope = query.scope || "/";
   var outputOptions = {
-    filename: "[hash].serviceworker.js",
-    chunkFilename: "[id].[hash].serviceworker.js",
+    filename: query.name || "sw.js",
+    chunkFilename: query.name || "sw.js",
     namedChunkFilename: null
   };
   if(this.options && this.options.worker && this.options.worker.output) {
@@ -38,7 +39,7 @@ module.exports.pitch = function(request) {
     if(err) return callback(err);
     if (entries[0]) {
         var workerFile = entries[0].files[0];
-        return callback(null, "module.exports = function(options) {\n\treturn navigator.serviceWorker.register(__webpack_public_path__ + " + JSON.stringify(workerFile) + ", options);\n};");
+        return callback(null, "module.exports = function(options) {\n\treturn navigator.serviceWorker.register(" + JSON.stringify(scope + workerFile) + ", options);\n};");
     } else {
         return callback(null, null);
     }


### PR DESCRIPTION
In contrast to webworkers the [virtual location of a service worker is important](https://jakearchibald.com/2014/launching-sw-without-breaking-the-web/) to define the scope.
Using the query parameters for 'scope' and 'name' allows the required configuration on usage.
