### PR TITLE
Don't stop build if there is a syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,11 @@ module.exports.pitch = function(request) {
   });
   workerCompiler.runAsChild(function(err, entries, compilation) {
     if(err) return callback(err);
-    var workerFile = entries[0].files[0];
-    return callback(null, "module.exports = function(options) {\n\treturn navigator.serviceWorker.register(__webpack_public_path__ + " + JSON.stringify(workerFile) + ", options);\n};");
+    if(entires[0]) {
+      var workerFile = entries[0].files[0];
+      return callback(null, "module.exports = function(options) {\n\treturn navigator.serviceWorker.register(__webpack_public_path__ + " + JSON.stringify(workerFile) + ", options);\n};");
+    } else {
+      return callback(null, null);
+    }
   });
 }


### PR DESCRIPTION
If the worker script has a syntax error it's hard to know what the issue is so guard against that and let the build continue. 

If an error occurs webpack will output a nice stack trace.

Literally spent way too much time wondering why it wasn't working to find out I had a semicolon where it shouldn't of been.

![](http://i.kinja-img.com/gawker-media/image/upload/s--FT8irOtq--/n1moetmwtpdutpv5jriy.jpg)
