### PR TITLE
Add query parameters nohash and filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,21 @@ var registerServiceWorker = require("serviceworker!./sw.js");
 registerServiceWorker({ scope: '/' }).then(success, error);
 ```
 
+### Options
+
+You can pass the name of the serviceworker file as a parameter with `filename`
+
+```javascript
+var registerServiceWorker = require("serviceworker?filename=anotherserviceworker.js!./sw.js");
+```
+
+By default it adds a hash to the filename so every build it would create a different file. E.g. Would create a file 45fb4c9e6f1e0bd99735.serviceworker.js
+You can remove that has option with the parameter `nohash`.
+
+```javascript
+var registerServiceWorker = require("serviceworker?nohash!./sw.js");
+```
+
 ## Credit
 
 This loader is based almost entirely on [worker-loader](https://github.com/webpack/worker-loader) by [@sokra](https://github.com/sokra).

--- a/index.js
+++ b/index.js
@@ -8,9 +8,11 @@ module.exports.pitch = function(request) {
   if(!this.webpack) throw new Error("Only usable with webpack");
   var callback = this.async();
   var query = loaderUtils.parseQuery(this.query);
+  var filename = query.filename || "serviceworker.js";
+  if(!query.nohash) filename = "[hash]." + filename;
   var outputOptions = {
-    filename: "[hash].serviceworker.js",
-    chunkFilename: "[id].[hash].serviceworker.js",
+    filename: filename,
+    chunkFilename: "[id]." + filename,
     namedChunkFilename: null
   };
   if(this.options && this.options.worker && this.options.worker.output) {


### PR DESCRIPTION
Removing the hash for development allows it to reload the serviceworker easily.
The hash in the other hand is good to be used for Production.

If developing different serviceworkers being able to modify the name of the file is a must.
